### PR TITLE
minor pod formatting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ list - see [Web::Library](https://metacpan.org/pod/Web::Library)'s `css_link_tag
 methods for an explanation of the concept.
 
 - Version 1.4.4
-=item Version 1.5.0
-=item Version 1.5.1
-=item Version 1.5.2 (the default)
+- Version 1.5.0
+- Version 1.5.1
+- Version 1.5.2 (the default)
 
         * js/underscore-min.js
 

--- a/lib/Web/Library/UnderscoreJS.pm
+++ b/lib/Web/Library/UnderscoreJS.pm
@@ -43,8 +43,11 @@ methods for an explanation of the concept.
 =over 4
 
 =item Version 1.4.4
+
 =item Version 1.5.0
+
 =item Version 1.5.1
+
 =item Version 1.5.2 (the default)
 
     * js/underscore-min.js


### PR DESCRIPTION
Hi Marcel! Me again :)

The `=item` version list needs to have a space between them, otherwise they appear unformatted and in the same line (as you can see on the MetaCPAN page for this dist). It also means it failed to convert the items to a list when the pod was turned into markdown.

This patch fixes them both, and now the version listing is shown properly formatted in both the pod and the markdown README.

Hope it helps! Thanks again for all the great software you give to the world :)

Cheers!